### PR TITLE
iOS/Safariで背景画像がおかしくなるのを修正

### DIFF
--- a/responsive.css
+++ b/responsive.css
@@ -1,3 +1,9 @@
+@media screen and (max-width: 1024px) {
+  .top-wrapper {
+    background-attachment: scroll;
+  }
+}
+
 @media screen and (max-width: 1000px) {
 /*header css start*/
 .header-left{


### PR DESCRIPTION
横幅1024px以下の端末はパララックス効果を無効化